### PR TITLE
Any file changes that occurred before InotifyFileWatcher was started but after the preceding EOF would not be detected

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -17,14 +17,19 @@ type Logger struct {
 
 var LOGGER = &Logger{log.New(os.Stderr, "", log.LstdFlags)}
 
-// fatal is like panic except it displays only the current goroutine's stack.
+// Fatal is like panic except it displays only the current goroutine's stack.
 func Fatal(format string, v ...interface{}) {
 	// https://github.com/nxadm/log/blob/master/log.go#L45
 	LOGGER.Output(2, fmt.Sprintf("FATAL -- "+format, v...)+"\n"+string(debug.Stack()))
 	os.Exit(1)
 }
 
-// partitionString partitions the string into chunks of given size,
+// Error logs an error message with the current goroutine stack and returns. It doesn't quit.
+func Error(format string, v ...interface{}) {
+	LOGGER.Output(2, fmt.Sprintf("ERROR -- "+format, v...)+"\n"+string(debug.Stack()))
+}
+
+// PartitionString partitions the string into chunks of given size,
 // with the last chunk of variable size.
 func PartitionString(s string, chunkSize int) []string {
 	if chunkSize <= 0 {


### PR DESCRIPTION
## Description

Tail starts the FileWatcher (both INotify and Polling versions) once it detects an EOF for the first time (if follow is enabled). 

If in between the EOF and when the INotifyFileWatcher starts, the file is modified, it won't notice the changes made to the file. This fix checks manually right after the watcher begins (without using fsnotify) if the file was modified and sends a delete, modify or truncate notification as appropriate.

This isn't a major concern if the file that's being tailed has a lot of modifications (e.g. audit log), because the next write will end up picking up all modifications, but it's still accurate.

Note: The upstream has a [PR](https://github.com/hpcloud/tail/pull/116) that tries to start the watcher right before the tailing begins. Unfortunately this causes a few tests related to re-seeking to fail. That is because the watcher relies on the fact that when it's started, its initial position is the size of the file at the point it's started. It uses that to detect if a file was truncated. If the position is 0 (as it would be at the start), it would never detect the first truncation and lines would be missed. While that could be re-written, I feel it's safer to keep that behavior as others could be relying on it (it's been there since the original fork of this project).

## Testing Performed

It's not straight forward to simulate this behavior via a unit test. However it can be faked by adding in explict sleep commands within the tail itself. Namely in the `waitForChanges` method of tail.go:
```
func (tail *Tail) waitForChanges() error {
	if tail.changes == nil {
                 time.Sleep(5 * time.Second)
		pos, err := tail.file.Seek(0, io.SeekCurrent)
		if err != nil {
			return err
		}
		tail.changes, err = tail.watcher.ChangeEvents(&tail.Tomb, pos)
		if err != nil {
			return err
		}
	}
        // snip...
}
```

Once that sleep is added it recreates the scenario where things could get written to post-EOF and pre-watcher start. Thanks @misberner for the suggestion!

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
